### PR TITLE
Fix nikola.plejic.com

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -215,7 +215,7 @@ name = Nate Smith (nwjsmith)
 [https://medium.com/feed/@nikitavoloboev]
 name = Nikita Voloboev (nikivi)
 
-[https://https://nikola.plejic.com/feeds/all.atom.xml]
+[https://nikola.plejic.com/feeds/all.atom.xml]
 name = Nikola Plejić (nikola)
 
 [http://silky.github.io/atom.xml]


### PR DESCRIPTION
Hi, I want to change my current feed url from https://https//nikola.plejic.com/feeds/all.atom.xml to https://nikola.plejic.com/feeds/all.atom.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=MY_FEED_URL and it is valid!
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed to the planet! :+1:

Apologies for the silly mistake in the last PR. :)