### PR TITLE
Update entry to reflect domain change

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -50,6 +50,9 @@ name = Artemis (Artemix)
 [http://assorted-experience.blogspot.com/feeds/posts/default?alt=rss]
 name = Assorted Experience (kghose)
 
+[https://spacetime.dev/feed.xml]
+name = Awn Umar (awn)
+
 [https://benaiah.me/rss.xml]
 name = Benaiah Mischenko (benaiah)
 
@@ -85,9 +88,6 @@ name = Chris Aumann (chr4)
 
 [https://bluishcoder.co.nz/rss.xml]
 name = Chris Double (doublec)
-
-[https://cryptolosophy.org/feed.xml]
-name = Cryptolosophy (awn)
 
 [http://danluu.com/atom.xml]
 name = Dan Luu (dl)


### PR DESCRIPTION
Hi, I want to change my current feed url from https://cryptolosophy.org/feed.xml to https://spacetime.dev/feed.xml. The old domain actually redirects which is why surprisingly posts from the new domain still show up at https://crustaceans.hmmz.org/ (although with the wrong site name).

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://spacetime.dev/feed.xml and it is valid!
2. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed to the planet! :+1:
