### PR TITLE
Change rss feed location for user pzel

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -275,7 +275,7 @@ name = Sevan Janiyan (sevan)
 [https://sgoel.org/feeds/all.rss.xml]
 name = Siddhant Goel (siddhantgoel)
 
-[http://pzel.github.io/feed.xml]
+[https://pzel.name/feed.xml]
 name = Simon Zelazny (pzel)
 
 [https://singpolyma.net/category/tech/feed/]


### PR DESCRIPTION
# EDIT FEED
------------------------------------------------------------------------------
Hi, I want to change my current feed url from http://pzel.github.io/feed.xml to https://pzel.name/feed.xml

## I checked the following required validations:  (mark all 4 with [x])

1. [x] My feed is valid, I checked using https://validator.w3.org/feed/check.cgi?url=https://pzel.name/feed.xml and it is valid!
4. [x] I am aware that once my feed is added it can take a few hours to start being fetched (according to the server update cycle)

Thanks in advance for changing my feed to the planet! :+1: